### PR TITLE
Fix login URL

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -27,7 +27,7 @@ const {
 // ------
 
 const baseUrl = 'https://clients.boursorama.com'
-const urlLogin = baseUrl + '/connexion/saisie-mot-de-passe/'
+const urlLogin = baseUrl + '/connexion/saisie-mot-de-passe'
 const urlKeyboard = baseUrl + '/connexion/clavier-virtuel?_hinclude=1'
 const urlDownload = baseUrl + '/mon-budget/exporter-mouvements'
 const urlAccounts =


### PR DESCRIPTION
See details on [weboob](https://git.weboob.org/weboob/weboob/commit/be7e0390427ad125d598b680cb4403a5fd38e77b):

> When doing a request on the login url with a `/` at the end, we receive
a 301 and are redirected to the same url without a `/` at the end. And
because of the `/` that is expected in the url, we end up not finding
the page.
Removing the `/` at the end in the regex leads to no redirection and it
matches both cases.

>>>