### PR TITLE
Fix account number retrieval

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -283,11 +283,20 @@ async function parseBankAccounts($) {
     }
 
     const $ = await request({ uri: account.url })
-    const number = scrape($('h3.account-number'), {
+    let number = scrape($('h3.account-number'), {
       reference: {
         sel: 'strong'
       }
     })
+    // The display changed for some accounts: if the number is not available,
+    // try to retrieve it using the new method
+    if (number.reference === '') {
+      number = scrape($('.c-product-title'), {
+        reference: {
+          sel: 'h3.c-product-title__sublabel'
+        }
+      })
+    }
 
     account.number = number.reference
     account.vendorId = number.reference

--- a/src/lib.js
+++ b/src/lib.js
@@ -298,6 +298,17 @@ async function parseBankAccounts($) {
       })
     }
 
+    // Make sure an error is logged in case
+    // the account number is not correctly retrieved
+    if (
+      isNaN(number.reference) ||
+      number.reference == undefined ||
+      number.reference === ''
+    ) {
+      log('error', 'Failed to retrieve account number')
+      throw new Error(errors.UNKNOWN_ERROR)
+    }
+
     account.number = number.reference
     account.vendorId = number.reference
   }


### PR DESCRIPTION
* Fix account number retrieval, but keep the retro-compatibility as it seems to be necessary according to [this woob commit](https://gitlab.com/woob/woob/-/commit/870fde9f95d2c1b5b6a34aa82982c11995e1814b).
* Make sure the account number is retrieved, in order to avoid creating new accounts in Cozy at each konnector run when it is not.